### PR TITLE
Dynamic substitution of the 'container'||'container-Fluid' class

### DIFF
--- a/resources/assets/js/layouts/app.vue
+++ b/resources/assets/js/layouts/app.vue
@@ -2,7 +2,7 @@
   <div class="app-layout">
     <navbar></navbar>
 
-    <div class="container mt-4">
+    <div class="mt-4" v-bind:class="[fluidOrNotFluid]">
       <child/>
     </div>
   </div>
@@ -13,9 +13,44 @@ import Navbar from '~/components/Navbar'
 
 export default {
   name: 'app-layout',
-
   components: {
     Navbar
+  },
+  data()
+  {
+     return {
+          // default container classname
+          fluidOrNotFluid: 'container',
+          // pages, that non fluid design
+          nonFluidPages  : [
+              'home',
+              'settings',
+              'settings.profile',
+              'settings.password',
+              'login',
+              'register',
+              'password.reset',
+              'password.email',
+          ]
+     }
+  },
+  created()
+  {
+      this.refreshFluidorNotFluidClassName()
+  },
+  watch     : {
+      '$route': 'refreshFluidorNotFluidClassName'
+  },
+  methods   : {
+      refreshFluidorNotFluidClassName()
+      {
+          // overriding the class name depends on page name (see ../router/routes.js)
+          this.className = 'container';
+          if ( this.nonFluidPages.indexOf( this.$route.name ) < 0 )
+          {
+              this.className = 'container-fluid';
+          }
+      }
   }
 }
 </script>


### PR DESCRIPTION
Dynamic substitution of the 'container'||'container-Fluid' class depending on the route name (viewing page). Useful if you need to use fluid design on some pages.