### PR TITLE
not submitting forms with unchanged or implausible data

### DIFF
--- a/resources/assets/js/pages/settings/password.vue
+++ b/resources/assets/js/pages/settings/password.vue
@@ -1,6 +1,7 @@
 <template>
   <card :title="$t('your_password')">
     <form @submit.prevent="update" @keydown="form.onKeydown($event)">
+
       <alert-success :form="form" :message="$t('password_updated')"/>
 
       <!-- Password -->
@@ -24,7 +25,12 @@
       <!-- Submit Button -->
       <div class="form-group row">
         <div class="col-md-9 ml-md-auto">
-          <v-button :loading="form.busy" type="success">{{ $t('update') }}</v-button>
+          <v-button
+              :loading="form.busy"
+              :disabled="!formValid"
+              type="success">
+            {{ $t('update') }}
+          </v-button>
         </div>
       </div>
     </form>
@@ -45,8 +51,19 @@ export default {
     form: new Form({
       password: '',
       password_confirmation: ''
-    })
+    }),
+    formValid: false
   }),
+
+  updated () {
+    if (this.form.password
+    && this.form.password_confirmation
+    && this.form.password === this.form.password_confirmation) {
+      this.formValid = true
+    } else {
+      this.formValid = false
+    }
+  },
 
   methods: {
     async update () {

--- a/resources/assets/js/pages/settings/profile.vue
+++ b/resources/assets/js/pages/settings/profile.vue
@@ -7,7 +7,10 @@
       <div class="form-group row">
         <label class="col-md-3 col-form-label text-md-right">{{ $t('name') }}</label>
         <div class="col-md-7">
-          <input v-model="form.name" :class="{ 'is-invalid': form.errors.has('name') }" class="form-control" type="text" name="name">
+          <input v-model="form.name"
+              :class="{ 'is-invalid': form.errors.has('name') }"
+              class="form-control"
+              type="text" name="name">
           <has-error :form="form" field="name"/>
         </div>
       </div>
@@ -24,7 +27,11 @@
       <!-- Submit Button -->
       <div class="form-group row">
         <div class="col-md-9 ml-md-auto">
-          <v-button :loading="form.busy" type="success">{{ $t('update') }}</v-button>
+          <v-button
+              :loading="form.busy"
+              :disabled="!formChanged"
+              type="success">
+            {{ $t('update') }}</v-button>
         </div>
       </div>
     </form>
@@ -43,11 +50,16 @@ export default {
   },
 
   data: () => ({
+    formChanged: false,
     form: new Form({
       name: '',
       email: ''
     })
   }),
+
+  updated () {
+    this.formChanged = true
+  },
 
   computed: mapGetters({
     user: 'auth/user'


### PR DESCRIPTION
Just a simple form validation that avoids sending obviously implausible data to the backend, like empty passwords or unchanged form data on the profile page. The ultimate validation is still done on the backend.