### PR TITLE
Update FontAwesome packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "lint": "vue-cli-service lint resources/js"
   },
   "dependencies": {
-    "@fortawesome/fontawesome": "^1.1.7",
-    "@fortawesome/fontawesome-free-brands": "^5.0.12",
-    "@fortawesome/fontawesome-free-regular": "^5.0.12",
-    "@fortawesome/fontawesome-free-solid": "^5.0.12",
-    "@fortawesome/vue-fontawesome": "^0.0.22",
+    "@fortawesome/fontawesome-svg-core": "^1.2.6",
+    "@fortawesome/free-brands-svg-icons": "^5.4.1",
+    "@fortawesome/free-regular-svg-icons": "^5.4.1",
+    "@fortawesome/free-solid-svg-icons": "^5.4.1",
+    "@fortawesome/vue-fontawesome": "^0.1.1",
     "axios": "^0.18.0",
     "bootstrap": "^4.1.1",
     "jquery": "^3.3.1",

--- a/resources/js/plugins/fontawesome.js
+++ b/resources/js/plugins/fontawesome.js
@@ -1,16 +1,16 @@
 import Vue from 'vue'
-import fontawesome from '@fortawesome/fontawesome'
-import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-// import { } from '@fortawesome/fontawesome-free-regular/shakable.es'
+// import { } from '@fortawesome/free-regular-svg-icons'
 
 import {
   faUser, faLock, faSignOutAlt, faCog
-} from '@fortawesome/fontawesome-free-solid/shakable.es'
+} from '@fortawesome/free-solid-svg-icons'
 
 import {
   faGithub
-} from '@fortawesome/fontawesome-free-brands/shakable.es'
+} from '@fortawesome/free-brands-svg-icons'
 
 fontawesome.library.add(
   faUser, faLock, faSignOutAlt, faCog, faGithub


### PR DESCRIPTION
Old packages have now been deprecated. They are still available but will only receive high priority patch release fixes.
[Vue-fontawesome info](https://github.com/FortAwesome/vue-fontawesome/blob/master/UPGRADING.md#00x-to-010)