### PR TITLE
Changing cookie ['locale'] manually to a key that not exists breaks the application

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -5,6 +5,11 @@ $config = [
     'locales' => config('app.locales'),
     'githubAuth' => config('services.github.client_id'),
 ];
+
+if ( isset ( $_COOKIE['locale'] ) AND ! array_key_exists( $_COOKIE['locale'] ,  $config['locales'] ) ) {
+    setcookie ( 'locale', $config['locale'], time() + ( 86400 ), "/");
+}
+
 @endphp
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">


### PR DESCRIPTION
Changing cookie ['locale'] manually to a key that not exists breaks the application

Here the example :
![image](https://user-images.githubusercontent.com/33966960/66666368-5b980280-ec48-11e9-95f1-8934f15f5e73.png)
![image](https://user-images.githubusercontent.com/33966960/66666385-66eb2e00-ec48-11e9-818c-50afc6f54294.png)