### PR TITLE
Add delay to scroll for less jarring page transitions

### DIFF
--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -190,7 +190,11 @@ function scrollBehavior (to, from, savedPosition) {
     return {}
   }
 
-  return { x: 0, y: 0 }
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({ x: 0, y: 0 })
+    }, 190)
+  })
 }
 
 /**


### PR DESCRIPTION
PR with code suggested by @bmpf in issue #201 .  I experimented a bit with the timeout, and if you use much less than 190 the effect is quite jarring (almost as bad as not making the change at all).  Longer than 190 and the animated transition finishes, then after a slight delay you jump to the top of the page.  190 seems to be a sweet spot where the scroll upwards occurs just as the animation finishes and it looks quite smooth.