### PR TITLE
Ensure cookie contains known locale

### DIFF
--- a/resources/js/store/modules/lang.js
+++ b/resources/js/store/modules/lang.js
@@ -3,9 +3,19 @@ import * as types from '../mutation-types'
 
 const { locale, locales } = window.config
 
+function validateCookieLocale () {
+  const cookieLocale = Cookies.get('locale') || locale
+  if (locales.hasOwnProperty(cookieLocale)) {
+    return cookieLocale
+  } else {
+    Cookies.set('locale', locale, { expires: 365 })
+    return locale
+  }
+}
+
 // state
 export const state = {
-  locale: Cookies.get('locale') || locale,
+  locale: validateCookieLocale(),
   locales: locales
 }
 


### PR DESCRIPTION
This is an alternate fix for @bmpf issue #213 ...  The originally suggested fix of modifying the blade template directly referencing superglobals felt a bit messy to me.  Givewn that the issue is the Vuex store being initialised with an invalid value, I thought it'd be better to fix the issue in the store itself, and have the store validate it's data on initialisation.