### PR TITLE
Fix sending extra verification email during registration, update tests

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,9 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Event;
-use Illuminate\Auth\Events\Registered;
-use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -14,11 +11,7 @@ class EventServiceProvider extends ServiceProvider
      *
      * @var array
      */
-    protected $listen = [
-        Registered::class => [
-            SendEmailVerificationNotification::class,
-        ],
-    ];
+    protected $listen = [];
 
     /**
      * Register any events for your application.

--- a/tests/Browser/RegisterTest.php
+++ b/tests/Browser/RegisterTest.php
@@ -4,9 +4,9 @@ namespace Tests\Browser;
 
 use App\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Tests\DuskTestCase;
 use Tests\Browser\Pages\Home;
 use Tests\Browser\Pages\Register;
+use Tests\DuskTestCase;
 
 class RegisterTest extends DuskTestCase
 {

--- a/tests/Browser/RegisterTest.php
+++ b/tests/Browser/RegisterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Browser;
 
 use App\User;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Tests\DuskTestCase;
 use Tests\Browser\Pages\Home;
 use Tests\Browser\Pages\Register;
@@ -27,7 +28,7 @@ class RegisterTest extends DuskTestCase
                     'password' => 'password',
                     'password_confirmation' => 'password',
                 ])
-                ->assertPageIs(Home::class);
+                ->assertPageIs(new User instanceof MustVerifyEmail ? Register::class : Home::class);
         });
     }
 

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\User;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Tests\TestCase;
 
 class RegisterTest extends TestCase
@@ -17,7 +18,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'secret',
         ])
         ->assertSuccessful()
-        ->assertJsonStructure(['id', 'name', 'email']);
+        ->assertJsonStructure(new User instanceof MustVerifyEmail ? ['status'] : ['id', 'name', 'email']);
     }
 
     /** @test */


### PR DESCRIPTION
Currently two emails are being sent for email verification if `User` implements `MustVerifyEmail`.
One is sent through `RegisterController.php`:
```php
if ($user instanceof MustVerifyEmail) {
            $user->sendEmailVerificationNotification();
```
And another one through `EventServiceProvider.php`:
```php
Registered::class => [
    SendEmailVerificationNotification::class,
],
```

Removing either one works but I removed the latter.

I also updated the tests to handle the case where `User` implements `MustVerifyEmail`, but they are far from perfect since notifications cannot be mocked in Dusk without additional dependencies (like `noeldemartin/laravel-dusk-mocking`). So for the `register_with_valid_data` test, it's only checked that the user stays on the same page since the email fails to send.