### PR TITLE
Move API route from /api to any base route (e. g. /api/v1)

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -38,7 +38,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         $this->routes(function () {
-            Route::prefix('api')
+            Route::prefix('api/v1')
                 ->middleware('api')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,6 +20,15 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
+     * The path to the "Base API" route for your application.
+     *
+     * This is used by api middleware and tests.
+     *
+     * @var string
+     */
+    public const API_BASE_URL = 'api/v1';
+
+    /**
      * The controller namespace for the application.
      *
      * When present, controller route declarations will automatically be prefixed with this namespace.
@@ -38,7 +47,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         $this->routes(function () {
-            Route::prefix('api/v1')
+            Route::prefix(self::API_BASE_URL)
                 ->middleware('api')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));

--- a/resources/js/components/LoginWithGithub.vue
+++ b/resources/js/components/LoginWithGithub.vue
@@ -11,7 +11,7 @@ export default {
 
   computed: {
     githubAuth: () => window.config.githubAuth,
-    url: () => '/api/oauth/github'
+    url: () => this.$store.getters['core/baseUrl'] + 'oauth/github'
   },
 
   mounted () {
@@ -27,7 +27,8 @@ export default {
       const newWindow = openWindow('', this.$t('login'))
 
       const url = await this.$store.dispatch('auth/fetchOauthUrl', {
-        provider: 'github'
+        provider: 'github',
+        baseUrl: this.$store.getters['core/baseUrl']
       })
 
       newWindow.location.href = url

--- a/resources/js/components/Navbar.vue
+++ b/resources/js/components/Navbar.vue
@@ -78,7 +78,7 @@ export default {
   methods: {
     async logout () {
       // Log out the user.
-      await this.$store.dispatch('auth/logout')
+      await this.$store.dispatch('auth/logout', { baseUrl: this.$store.getters['core/baseUrl'] })
 
       // Redirect to login.
       this.$router.push({ name: 'login' })

--- a/resources/js/middleware/check-auth.js
+++ b/resources/js/middleware/check-auth.js
@@ -3,7 +3,7 @@ import store from '~/store'
 export default async (to, from, next) => {
   if (!store.getters['auth/check'] && store.getters['auth/token']) {
     try {
-      await store.dispatch('auth/fetchUser')
+      await store.dispatch('auth/fetchUser', { baseUrl: store.getters['core/baseUrl'] })
     } catch (e) { }
   }
 

--- a/resources/js/pages/auth/login.vue
+++ b/resources/js/pages/auth/login.vue
@@ -79,7 +79,7 @@ export default {
   methods: {
     async login () {
       // Submit the form.
-      const { data } = await this.form.post('/api/login')
+      const { data } = await this.form.post(this.$store.getters['core/baseUrl'] + 'login')
 
       // Save the token.
       this.$store.dispatch('auth/saveToken', {
@@ -88,7 +88,7 @@ export default {
       })
 
       // Fetch the user.
-      await this.$store.dispatch('auth/fetchUser')
+      await this.$store.dispatch('auth/fetchUser', { baseUrl: this.$store.getters['core/baseUrl'] })
 
       // Redirect home.
       this.redirect()

--- a/resources/js/pages/auth/password/email.vue
+++ b/resources/js/pages/auth/password/email.vue
@@ -47,7 +47,7 @@ export default {
 
   methods: {
     async send () {
-      const { data } = await this.form.post('/api/password/email')
+      const { data } = await this.form.post(this.$store.getters['core/baseUrl'] + 'password/email')
 
       this.status = data.status
 

--- a/resources/js/pages/auth/password/reset.vue
+++ b/resources/js/pages/auth/password/reset.vue
@@ -73,7 +73,7 @@ export default {
 
   methods: {
     async reset () {
-      const { data } = await this.form.post('/api/password/reset')
+      const { data } = await this.form.post(this.$store.getters['core/baseUrl'] + 'password/reset')
 
       this.status = data.status
 

--- a/resources/js/pages/auth/register.vue
+++ b/resources/js/pages/auth/register.vue
@@ -89,14 +89,14 @@ export default {
   methods: {
     async register () {
       // Register the user.
-      const { data } = await this.form.post('/api/register')
+      const { data } = await this.form.post(this.$store.getters['core/baseUrl'] + 'register')
 
       // Must verify email fist.
       if (data.status) {
         this.mustVerifyEmail = true
       } else {
         // Log in the user.
-        const { data: { token } } = await this.form.post('/api/login')
+        const { data: { token } } = await this.form.post(this.$store.getters['core/baseUrl'] + 'login')
 
         // Save the token.
         this.$store.dispatch('auth/saveToken', { token })

--- a/resources/js/pages/auth/verification/resend.vue
+++ b/resources/js/pages/auth/verification/resend.vue
@@ -53,7 +53,7 @@ export default {
 
   methods: {
     async send () {
-      const { data } = await this.form.post('/api/email/resend')
+      const { data } = await this.form.post(this.$store.getters['core/baseUrl'] + 'email/resend')
 
       this.status = data.status
 

--- a/resources/js/pages/auth/verification/verify.vue
+++ b/resources/js/pages/auth/verification/verify.vue
@@ -33,7 +33,7 @@ const qs = (params) => Object.keys(params).map(key => `${key}=${params[key]}`).j
 export default {
   async beforeRouteEnter (to, from, next) {
     try {
-      const { data } = await axios.post(`/api/email/verify/${to.params.id}?${qs(to.query)}`)
+      const { data } = await axios.post(this.$store.getters['core/baseUrl'] + `email/verify/${to.params.id}?${qs(to.query)}`)
 
       next(vm => { vm.success = data.status })
     } catch (e) {

--- a/resources/js/pages/settings/password.vue
+++ b/resources/js/pages/settings/password.vue
@@ -52,7 +52,7 @@ export default {
 
   methods: {
     async update () {
-      await this.form.patch('/api/settings/password')
+      await this.form.patch(this.$store.getters['core/baseUrl'] + 'settings/password')
 
       this.form.reset()
     }

--- a/resources/js/pages/settings/profile.vue
+++ b/resources/js/pages/settings/profile.vue
@@ -64,7 +64,7 @@ export default {
 
   methods: {
     async update () {
-      const { data } = await this.form.patch('/api/settings/profile')
+      const { data } = await this.form.patch(this.$store.getters['core/baseUrl'] + 'settings/profile')
 
       this.$store.dispatch('auth/updateUser', { user: data })
     }

--- a/resources/js/plugins/axios.js
+++ b/resources/js/plugins/axios.js
@@ -45,7 +45,7 @@ axios.interceptors.response.use(response => response, error => {
       confirmButtonText: i18n.t('ok'),
       cancelButtonText: i18n.t('cancel')
     }).then(() => {
-      store.commit('auth/LOGOUT')
+      store.commit('auth/LOGOUT', { baseUrl: store.getters['core/baseUrl'] })
 
       router.push({ name: 'login' })
     })

--- a/resources/js/store/modules/auth.js
+++ b/resources/js/store/modules/auth.js
@@ -17,41 +17,41 @@ export const getters = {
 
 // mutations
 export const mutations = {
-  [types.SAVE_TOKEN] (state, { token, remember }) {
+  [types.SAVE_TOKEN](state, { token, remember }) {
     state.token = token
     Cookies.set('token', token, { expires: remember ? 365 : null })
   },
 
-  [types.FETCH_USER_SUCCESS] (state, { user }) {
+  [types.FETCH_USER_SUCCESS](state, { user }) {
     state.user = user
   },
 
-  [types.FETCH_USER_FAILURE] (state) {
+  [types.FETCH_USER_FAILURE](state) {
     state.token = null
     Cookies.remove('token')
   },
 
-  [types.LOGOUT] (state) {
+  [types.LOGOUT](state) {
     state.user = null
     state.token = null
 
     Cookies.remove('token')
   },
 
-  [types.UPDATE_USER] (state, { user }) {
+  [types.UPDATE_USER](state, { user }) {
     state.user = user
   }
 }
 
 // actions
 export const actions = {
-  saveToken ({ commit, dispatch }, payload) {
+  saveToken({ commit, dispatch }, payload) {
     commit(types.SAVE_TOKEN, payload)
   },
 
-  async fetchUser ({ commit }) {
+  async fetchUser({ commit }, payload) {
     try {
-      const { data } = await axios.get('/api/user')
+      const { data } = await axios.get(payload.baseUrl + 'user')
 
       commit(types.FETCH_USER_SUCCESS, { user: data })
     } catch (e) {
@@ -59,20 +59,20 @@ export const actions = {
     }
   },
 
-  updateUser ({ commit }, payload) {
+  updateUser({ commit }, payload) {
     commit(types.UPDATE_USER, payload)
   },
 
-  async logout ({ commit }) {
+  async logout({ commit }, payload) {
     try {
-      await axios.post('/api/logout')
+      await axios.post(payload.baseUrl + 'logout')
     } catch (e) { }
 
     commit(types.LOGOUT)
   },
 
-  async fetchOauthUrl (ctx, { provider }) {
-    const { data } = await axios.post(`/api/oauth/${provider}`)
+  async fetchOauthUrl(ctx, { provider, baseUrl }) {
+    const { data } = await axios.post(baseUrl + `oauth/${provider}`)
 
     return data.url
   }

--- a/resources/js/store/modules/core.js
+++ b/resources/js/store/modules/core.js
@@ -1,0 +1,15 @@
+// state
+export const state = {
+  baseUrl: '/api/v1/'
+}
+
+// getters
+export const getters = {
+  baseUrl: state => state.baseUrl
+}
+
+// mutations
+export const mutations = {}
+
+// actions
+export const actions = {}

--- a/tests/Feature/LocaleTest.php
+++ b/tests/Feature/LocaleTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class LocaleTest extends TestCase
 {
@@ -11,7 +11,7 @@ class LocaleTest extends TestCase
     public function set_locale_from_header()
     {
         $this->withHeaders(['Accept-Language' => 'zh-CN'])
-            ->postJson(RouteServiceProvider::API_BASE_URL . '/login');
+            ->postJson(RouteServiceProvider::API_BASE_URL.'/login');
 
         $this->assertEquals('zh-CN', $this->app->getLocale());
     }
@@ -20,7 +20,7 @@ class LocaleTest extends TestCase
     public function set_locale_from_header_short()
     {
         $this->withHeaders(['Accept-Language' => 'en-US'])
-            ->postJson(RouteServiceProvider::API_BASE_URL . '/login');
+            ->postJson(RouteServiceProvider::API_BASE_URL.'/login');
 
         $this->assertEquals('en', $this->app->getLocale());
     }

--- a/tests/Feature/LocaleTest.php
+++ b/tests/Feature/LocaleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class LocaleTest extends TestCase
 {
@@ -10,7 +11,7 @@ class LocaleTest extends TestCase
     public function set_locale_from_header()
     {
         $this->withHeaders(['Accept-Language' => 'zh-CN'])
-            ->postJson('/api/login');
+            ->postJson(RouteServiceProvider::API_BASE_URL . '/login');
 
         $this->assertEquals('zh-CN', $this->app->getLocale());
     }
@@ -19,7 +20,7 @@ class LocaleTest extends TestCase
     public function set_locale_from_header_short()
     {
         $this->withHeaders(['Accept-Language' => 'en-US'])
-            ->postJson('/api/login');
+            ->postJson(RouteServiceProvider::API_BASE_URL . '/login');
 
         $this->assertEquals('en', $this->app->getLocale());
     }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class LoginTest extends TestCase
 {
@@ -13,7 +13,7 @@ class LoginTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/login', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/login', [
             'email' => $user->email,
             'password' => 'password',
         ])
@@ -26,7 +26,7 @@ class LoginTest extends TestCase
     public function fetch_the_current_user()
     {
         $this->actingAs(User::factory()->create())
-            ->getJson(RouteServiceProvider::API_BASE_URL . '/user')
+            ->getJson(RouteServiceProvider::API_BASE_URL.'/user')
             ->assertSuccessful()
             ->assertJsonStructure(['id', 'name', 'email']);
     }
@@ -34,15 +34,15 @@ class LoginTest extends TestCase
     /** @test */
     public function log_out()
     {
-        $token = $this->postJson(RouteServiceProvider::API_BASE_URL . '/login', [
+        $token = $this->postJson(RouteServiceProvider::API_BASE_URL.'/login', [
             'email' => User::factory()->create()->email,
             'password' => 'password',
         ])->json()['token'];
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . "/logout?token=$token")
+        $this->postJson(RouteServiceProvider::API_BASE_URL."/logout?token=$token")
             ->assertSuccessful();
 
-        $this->getJson(RouteServiceProvider::API_BASE_URL . "/user?token=$token")
+        $this->getJson(RouteServiceProvider::API_BASE_URL."/user?token=$token")
             ->assertStatus(401);
     }
 }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class LoginTest extends TestCase
 {
@@ -12,7 +13,7 @@ class LoginTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->postJson('/api/login', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/login', [
             'email' => $user->email,
             'password' => 'password',
         ])
@@ -25,7 +26,7 @@ class LoginTest extends TestCase
     public function fetch_the_current_user()
     {
         $this->actingAs(User::factory()->create())
-            ->getJson('/api/user')
+            ->getJson(RouteServiceProvider::API_BASE_URL . '/user')
             ->assertSuccessful()
             ->assertJsonStructure(['id', 'name', 'email']);
     }
@@ -33,15 +34,15 @@ class LoginTest extends TestCase
     /** @test */
     public function log_out()
     {
-        $token = $this->postJson('/api/login', [
+        $token = $this->postJson(RouteServiceProvider::API_BASE_URL . '/login', [
             'email' => User::factory()->create()->email,
             'password' => 'password',
         ])->json()['token'];
 
-        $this->postJson("/api/logout?token=$token")
+        $this->postJson(RouteServiceProvider::API_BASE_URL . "/logout?token=$token")
             ->assertSuccessful();
 
-        $this->getJson("/api/user?token=$token")
+        $this->getJson(RouteServiceProvider::API_BASE_URL . "/user?token=$token")
             ->assertStatus(401);
     }
 }

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -10,6 +10,7 @@ use Laravel\Socialite\Two\User as SocialiteUser;
 use Mockery as m;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class OAuthTest extends TestCase
 {
@@ -35,7 +36,7 @@ class OAuthTest extends TestCase
     {
         $this->mockSocialite('github');
 
-        $this->postJson('/api/oauth/github')
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/oauth/github')
             ->assertSuccessful()
             ->assertJson(['url' => 'https://url-to-provider']);
     }
@@ -53,7 +54,7 @@ class OAuthTest extends TestCase
 
         $this->withoutExceptionHandling();
 
-        $this->get('/api/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
             ->assertText('token')
             ->assertSuccessful();
 
@@ -87,7 +88,7 @@ class OAuthTest extends TestCase
             'refreshToken' => 'updated-refresh-token',
         ]);
 
-        $this->get('/api/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
             ->assertText('token')
             ->assertSuccessful();
 
@@ -105,7 +106,7 @@ class OAuthTest extends TestCase
 
         $this->mockSocialite('github', ['email' => 'test@example.com']);
 
-        $this->get('/api/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
             ->assertText('Email already taken.')
             ->assertTextMissing('token')
             ->assertStatus(400);

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -3,13 +3,13 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Mockery as m;
 use PHPUnit\Framework\Assert as PHPUnit;
-use App\Providers\RouteServiceProvider;
 use Tests\TestCase;
 
 class OAuthTest extends TestCase

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -9,8 +9,8 @@ use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Mockery as m;
 use PHPUnit\Framework\Assert as PHPUnit;
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class OAuthTest extends TestCase
 {
@@ -36,7 +36,7 @@ class OAuthTest extends TestCase
     {
         $this->mockSocialite('github');
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/oauth/github')
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/oauth/github')
             ->assertSuccessful()
             ->assertJson(['url' => 'https://url-to-provider']);
     }
@@ -54,7 +54,7 @@ class OAuthTest extends TestCase
 
         $this->withoutExceptionHandling();
 
-        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL.'/oauth/github/callback')
             ->assertText('token')
             ->assertSuccessful();
 
@@ -88,7 +88,7 @@ class OAuthTest extends TestCase
             'refreshToken' => 'updated-refresh-token',
         ]);
 
-        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL.'/oauth/github/callback')
             ->assertText('token')
             ->assertSuccessful();
 
@@ -106,7 +106,7 @@ class OAuthTest extends TestCase
 
         $this->mockSocialite('github', ['email' => 'test@example.com']);
 
-        $this->get(RouteServiceProvider::API_BASE_URL . '/oauth/github/callback')
+        $this->get(RouteServiceProvider::API_BASE_URL.'/oauth/github/callback')
             ->assertText('Email already taken.')
             ->assertTextMissing('token')
             ->assertStatus(400);

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -3,15 +3,15 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class RegisterTest extends TestCase
 {
     /** @test */
     public function can_register()
     {
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/register', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/register', [
             'name' => 'Test User',
             'email' => 'test@test.app',
             'password' => 'secret',
@@ -26,7 +26,7 @@ class RegisterTest extends TestCase
     {
         User::factory()->create(['email' => 'test@test.app']);
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/register', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/register', [
             'name' => 'Test User',
             'email' => 'test@test.app',
             'password' => 'secret',

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -4,13 +4,14 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class RegisterTest extends TestCase
 {
     /** @test */
     public function can_register()
     {
-        $this->postJson('/api/register', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/register', [
             'name' => 'Test User',
             'email' => 'test@test.app',
             'password' => 'secret',
@@ -25,7 +26,7 @@ class RegisterTest extends TestCase
     {
         User::factory()->create(['email' => 'test@test.app']);
 
-        $this->postJson('/api/register', [
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/register', [
             'name' => 'Test User',
             'email' => 'test@test.app',
             'password' => 'secret',

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Support\Facades\Hash;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class SettingsTest extends TestCase

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class SettingsTest extends TestCase
 {
@@ -13,7 +13,7 @@ class SettingsTest extends TestCase
     public function update_profile_info()
     {
         $this->actingAs($user = User::factory()->create())
-            ->patchJson(RouteServiceProvider::API_BASE_URL . '/settings/profile', [
+            ->patchJson(RouteServiceProvider::API_BASE_URL.'/settings/profile', [
                 'name' => 'Test User',
                 'email' => 'test@test.app',
             ])
@@ -31,7 +31,7 @@ class SettingsTest extends TestCase
     public function update_password()
     {
         $this->actingAs($user = User::factory()->create())
-            ->patchJson(RouteServiceProvider::API_BASE_URL . '/settings/password', [
+            ->patchJson(RouteServiceProvider::API_BASE_URL.'/settings/password', [
                 'password' => 'updated',
                 'password_confirmation' => 'updated',
             ])

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class SettingsTest extends TestCase
 {
@@ -12,7 +13,7 @@ class SettingsTest extends TestCase
     public function update_profile_info()
     {
         $this->actingAs($user = User::factory()->create())
-            ->patchJson('/api/settings/profile', [
+            ->patchJson(RouteServiceProvider::API_BASE_URL . '/settings/profile', [
                 'name' => 'Test User',
                 'email' => 'test@test.app',
             ])
@@ -30,7 +31,7 @@ class SettingsTest extends TestCase
     public function update_password()
     {
         $this->actingAs($user = User::factory()->create())
-            ->patchJson('/api/settings/password', [
+            ->patchJson(RouteServiceProvider::API_BASE_URL . '/settings/password', [
                 'password' => 'updated',
                 'password_confirmation' => 'updated',
             ])

--- a/tests/Feature/VerificationTest.php
+++ b/tests/Feature/VerificationTest.php
@@ -4,11 +4,11 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use App\Notifications\VerifyEmail;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
-use App\Providers\RouteServiceProvider;
 use Tests\TestCase;
 
 class VerificationTest extends TestCase

--- a/tests/Feature/VerificationTest.php
+++ b/tests/Feature/VerificationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
 use Tests\TestCase;
+use App\Providers\RouteServiceProvider;
 
 class VerificationTest extends TestCase
 {
@@ -45,7 +46,7 @@ class VerificationTest extends TestCase
     {
         $user = User::factory()->create(['email_verified_at' => null]);
 
-        $this->postJson("/api/email/verify/{$user->id}")
+        $this->postJson(RouteServiceProvider::API_BASE_URL . "/email/verify/{$user->id}")
             ->assertStatus(400)
             ->assertJsonFragment(['status' => 'The verification link is invalid.']);
     }
@@ -57,7 +58,7 @@ class VerificationTest extends TestCase
 
         Notification::fake();
 
-        $this->postJson('/api/email/resend', ['email' => $user->email])
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => $user->email])
             ->assertSuccessful();
 
         Notification::assertSentTo($user, VerifyEmail::class);
@@ -66,7 +67,7 @@ class VerificationTest extends TestCase
     /** @test */
     public function can_not_resend_verification_notification_if_email_does_not_exist()
     {
-        $this->postJson('/api/email/resend', ['email' => 'foo@bar.com'])
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => 'foo@bar.com'])
             ->assertStatus(422)
             ->assertJsonFragment(['errors' => ['email' => ['We can\'t find a user with that e-mail address.']]]);
     }
@@ -78,7 +79,7 @@ class VerificationTest extends TestCase
 
         Notification::fake();
 
-        $this->postJson('/api/email/resend', ['email' => $user->email])
+        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => $user->email])
             ->assertStatus(422)
             ->assertJsonFragment(['errors' => ['email' => ['The email is already verified.']]]);
 

--- a/tests/Feature/VerificationTest.php
+++ b/tests/Feature/VerificationTest.php
@@ -8,8 +8,8 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
-use Tests\TestCase;
 use App\Providers\RouteServiceProvider;
+use Tests\TestCase;
 
 class VerificationTest extends TestCase
 {
@@ -46,7 +46,7 @@ class VerificationTest extends TestCase
     {
         $user = User::factory()->create(['email_verified_at' => null]);
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . "/email/verify/{$user->id}")
+        $this->postJson(RouteServiceProvider::API_BASE_URL."/email/verify/{$user->id}")
             ->assertStatus(400)
             ->assertJsonFragment(['status' => 'The verification link is invalid.']);
     }
@@ -58,7 +58,7 @@ class VerificationTest extends TestCase
 
         Notification::fake();
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => $user->email])
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/email/resend', ['email' => $user->email])
             ->assertSuccessful();
 
         Notification::assertSentTo($user, VerifyEmail::class);
@@ -67,7 +67,7 @@ class VerificationTest extends TestCase
     /** @test */
     public function can_not_resend_verification_notification_if_email_does_not_exist()
     {
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => 'foo@bar.com'])
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/email/resend', ['email' => 'foo@bar.com'])
             ->assertStatus(422)
             ->assertJsonFragment(['errors' => ['email' => ['We can\'t find a user with that e-mail address.']]]);
     }
@@ -79,7 +79,7 @@ class VerificationTest extends TestCase
 
         Notification::fake();
 
-        $this->postJson(RouteServiceProvider::API_BASE_URL . '/email/resend', ['email' => $user->email])
+        $this->postJson(RouteServiceProvider::API_BASE_URL.'/email/resend', ['email' => $user->email])
             ->assertStatus(422)
             ->assertJsonFragment(['errors' => ['email' => ['The email is already verified.']]]);
 


### PR DESCRIPTION
Many programmers prefer to use route 'api/v1' instead of route '/api' or any custom base route for API. I made some changes that helps you to set base URL. You can set the base URL in the file 'resources/js/store/modules/core.js'  at the Line 3